### PR TITLE
Remove repeated Pansexual from mission statement

### DIFF
--- a/mission.md
+++ b/mission.md
@@ -16,5 +16,5 @@ This might include zero, one or more of the following: Agender,
 Androgyne, Asexual, Bicurious, Bigender, Bisexual, Demiboy, Demigirl, Demiguy, Elissogender, Enby,
 Feminine of Center, Gay, Gender Non-Conforming, Genderfluid, Genderflux, Genderqueer, Homosexual,
 Intergender, Intersexual, Lesbian, Masculine of Center, Maverique, Multigender, Multisexual, Neutrois,
-Non-Binary, Non-Monosexual, Novosexual, Pangender, Pansexual, Pansexual, Polygender, Polysexual, Queer,
+Non-Binary, Non-Monosexual, Novosexual, Pangender, Pansexual, Polygender, Polysexual, Queer,
 Questioning, Skoliosexual, Trans*, Transgender, Transsexual, Trigender.


### PR DESCRIPTION
The list of what is considered by the site as queer in the mission statement included "Pansexual" twice.

This patch removes one of the repetitions.
