### PR TITLE
Fix link to Github profile in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
                 <strong>Queer Code</strong>
 
 
-                <a href="https://github.com/QueerCodeBerlin">
+                <a href="https://github.com/QueerCodeOrg">
                 <span class="icon">
                     <i class="fa fa-github"></i>
                 </span>


### PR DESCRIPTION
This patch fixes the link from the footer of the website to the Github profile. 

Prior to this, it pointed to "QueerCodeBerlin", which resulted in a 404 error.
