### PR TITLE
fix : added some overriding style to show the whole slackin iframe.

### DIFF
--- a/_sass/queercode/components/slack.scss
+++ b/_sass/queercode/components/slack.scss
@@ -8,6 +8,15 @@
   width: 8em;
 }
 
+/* this is a bit of a hack to deal with bad styling in the slackin plugin */
+div.__slackin {
+  height: 30em !important;
+
+  iframe.__slackin {
+    height: 100% !important;
+  }
+}
+
 /* this is kinda naff, doing a negative margin */
 @media (min-width: 1024px) {
   .slack {


### PR DESCRIPTION
resolves #27 (in conjunction with the changes to the Heroku app)

![image](https://user-images.githubusercontent.com/439121/40445092-0e347d66-5ec3-11e8-82b7-9e961bdeba18.png)
