### PR TITLE
Fix GitHub security alert, and update header text

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 3.7.2"
+gem "jekyll", "~> 3.8.6"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
-    eventmachine (1.2.5)
-    ffi (1.9.21)
+    eventmachine (1.2.7)
+    ffi (1.11.1)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.7.2)
+    jekyll (3.8.6)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -33,10 +33,10 @@ GEM
       sass (~> 3.4)
     jekyll-seo-tag (2.4.0)
       jekyll (~> 3.3)
-    jekyll-watch (2.0.0)
+    jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (1.16.2)
-    liquid (4.0.0)
+    kramdown (1.17.0)
+    liquid (4.0.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -46,16 +46,16 @@ GEM
       jekyll (~> 3.5)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    pathutil (0.16.1)
+    pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (3.0.2)
-    rb-fsevent (0.10.2)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
-    rouge (3.1.1)
+    public_suffix (3.1.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    rouge (3.7.0)
     ruby_dep (1.5.0)
-    safe_yaml (1.0.4)
-    sass (3.5.5)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -65,10 +65,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 3.7.2)
+  jekyll (~> 3.8.6)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
   tzinfo-data
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@
 # feature for the data you need to update frequently.
 #
 title: Queer Code
-description: We've come together to connect and support queer people (of all flavors) working in jobs related to software development.
+description: We are a community of queer coders. We build tech together, share our ideas at local meetups, and provide support for queer people working in software development.
 sass:
     sass_dir: _sass
     style: compressed

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ layout: default
         <h3 class="title">Berlin</h3>
 
         <img class="image" src="images/city_berlin.jpg" alt="Berlin" />
-        
+
         <div class="links">
           <a class="button is-bordered is-rainbow" href="https://www.meetup.com/Queer-Code-Berlin/">
             <i class="fa fa-meetup" aria-hidden="true"></i> Join us
@@ -56,7 +56,7 @@ layout: default
         <h3 class="title">London</h3>
 
         <img class="image" src="images/city_london.jpg" alt="London" />
-            
+
         <div class="links">
           <a class="button is-bordered is-rainbow" href="https://www.meetup.com/Queer-Code-London/">
             <i class="fa fa-meetup" aria-hidden="true"></i> Join us
@@ -84,7 +84,7 @@ layout: default
         <h3 class="title">Yorkshire</h3>
 
         <img class="image" src="images/city_yorkshire.jpg" alt="Yorkshire" />
-        
+
         <div class="links">
           <a class="button is-bordered is-rainbow" href="https://www.eventbrite.com/o/queer-code-yorkshire-15310069508">
             Join us

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ layout: default
          {{ site.description }}
       </p>
       <p>
-        <a class="button is-bordered is-rainbow" href="/mission">Our mission</a>
+        Are you a queer coder? Like to take part? <a href="https://slackinvite-qcldn.herokuapp.com/">Join our Slack group</a> or look below to find an event near you.
       </p>
     </div>
   </div>


### PR DESCRIPTION
- Updates Jekyll dependency to clear GitHub security alert
- Updates site description to better describe what we do
- Replaces the 'Mission' button with a new call-to-action to join slack or find an event near you
- Also removes some spaces within blank lines that my editor was complaining about. 

This fixes #47 and #48.