### PR TITLE
Simplify local meetup listings, and merge Twitter timelines into one

### DIFF
--- a/_data/meetups.json
+++ b/_data/meetups.json
@@ -1,27 +1,27 @@
 [
   {
-    name: 'Berlin',
-    image: 'city_berlin.jpg',
-    joinLink: 'https://www.meetup.com/Queer-Code-Berlin/',
-    joinType: 'meetup',
-    github: 'https://github.com/QueerCodeOrg',
-    twitter: 'https://twitter.com/QueerCodeBerlin',
-    mail: 'mailto:queer-code-berlin@googlegroups.com'
+    "name": "Berlin",
+    "image": "city_berlin.jpg",
+    "joinLink": "https://www.meetup.com/Queer-Code-Berlin/",
+    "joinType": "meetup",
+    "github": "https://github.com/QueerCodeOrg",
+    "twitter": "https://twitter.com/QueerCodeBerlin",
+    "mail": "mailto:queer-code-berlin@googlegroups.com"
   },
   {
-    name: 'London',
-    image: 'city_london.jpg',
-    joinLink: 'https://www.meetup.com/Queer-Code-London/',
-    joinType: 'meetup',
-    github: 'https://github.com/QCLdn',
-    twitter: 'https://twitter.com/QCLdn',
-    mail: 'mailto:qclnd-orga@googlegroups.com'
+    "name": "London",
+    "image": "city_london.jpg",
+    "joinLink": "https://www.meetup.com/Queer-Code-London/",
+    "joinType": "meetup",
+    "github": "https://github.com/QCLdn",
+    "twitter": "https://twitter.com/QCLdn",
+    "mail": "mailto:qclnd-orga@googlegroups.com"
   },
   {
-    name: 'Yorkshire',
-    image: 'city_yorkshire.jpg',
-    joinLink: 'https://www.eventbrite.com/o/queer-code-yorkshire-15310069508',
-    joinType: 'eventbrite',
-    twitter: 'https://twitter.com/QueerCodeYorks',
+    "name": "Yorkshire",
+    "image": "city_yorkshire.jpg",
+    "joinLink": "https://www.eventbrite.com/o/queer-code-yorkshire-15310069508",
+    "joinType": "eventbrite",
+    "twitter": "https://twitter.com/QueerCodeYorks"
   }
 ]

--- a/_data/meetups.json
+++ b/_data/meetups.json
@@ -4,7 +4,7 @@
     image: 'city_berlin.jpg',
     joinLink: 'https://www.meetup.com/Queer-Code-Berlin/',
     joinType: 'meetup',
-    github: 'https://github.com/QueerCodeBerlin',
+    github: 'https://github.com/QueerCodeOrg',
     twitter: 'https://twitter.com/QueerCodeBerlin',
     mail: 'mailto:queer-code-berlin@googlegroups.com'
   },

--- a/_data/meetups.json
+++ b/_data/meetups.json
@@ -1,0 +1,27 @@
+[
+  {
+    name: 'Berlin',
+    image: 'city_berlin.jpg',
+    joinLink: 'https://www.meetup.com/Queer-Code-Berlin/',
+    joinType: 'meetup',
+    github: 'https://github.com/QueerCodeBerlin',
+    twitter: 'https://twitter.com/QueerCodeBerlin',
+    mail: 'mailto:queer-code-berlin@googlegroups.com'
+  },
+  {
+    name: 'London',
+    image: 'city_london.jpg',
+    joinLink: 'https://www.meetup.com/Queer-Code-London/',
+    joinType: 'meetup',
+    github: 'https://github.com/QCLdn',
+    twitter: 'https://twitter.com/QCLdn',
+    mail: 'mailto:qclnd-orga@googlegroups.com'
+  },
+  {
+    name: 'Yorkshire',
+    image: 'city_yorkshire.jpg',
+    joinLink: 'https://www.eventbrite.com/o/queer-code-yorkshire-15310069508',
+    joinType: 'eventbrite',
+    twitter: 'https://twitter.com/QueerCodeYorks',
+  }
+]

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -55,10 +55,6 @@
           <a class="navbar-item" href="coc">
             Code of Conduct
           </a>
-          <a class="navbar-item navbar-item--twitter" href="https://twitter.com/search?q=queercode">
-            <i class="fa fa-twitter" aria-hidden="true"></i>
-            #queercode
-          </a>
           <span class="navbar-item navbar-item--slack">
             <script async defer src="https://slackinvite-qcldn.herokuapp.com/slackin.js"></script>
           </span>

--- a/_sass/queercode/components/places.scss
+++ b/_sass/queercode/components/places.scss
@@ -1,9 +1,16 @@
+.places > .title {
+  font-size: 2em;
+  margin-left: 10px;
+  margin-top: 20px;
+}
+
 .place {
   padding: 10px;
 }
 
-.place .title {
-  font-size: 3em;
+.place >* .title {
+  font-size: 1.5em;
+  margin-bottom: 0;
 }
 
 .places .links {

--- a/_sass/queercode/components/places.scss
+++ b/_sass/queercode/components/places.scss
@@ -1,5 +1,4 @@
 .places > .title {
-  font-size: 2em;
   margin-left: 10px;
   margin-top: 20px;
 }

--- a/_sass/queercode/components/places.scss
+++ b/_sass/queercode/components/places.scss
@@ -1,14 +1,9 @@
-.places > .title {
-  font-size: 3em;
-  padding: 1rem;
-}
-
 .place {
-  padding: 1em;
+  padding: 10px;
 }
 
 .place .title {
-  margin-bottom: 1em;
+  font-size: 3em;
 }
 
 .places .links {
@@ -22,5 +17,5 @@
 }
 
 .place .image {
-  border-radius: 10px;
+  border-radius: 5px;
 }

--- a/_sass/queercode/components/places.scss
+++ b/_sass/queercode/components/places.scss
@@ -1,10 +1,10 @@
 .places > .title {
-  margin-left: 10px;
-  margin-top: 20px;
+  margin-left: 0.75rem;
+  margin-top: 1.25rem;
 }
 
 .place {
-  padding: 10px;
+  padding: 0.75rem;
 }
 
 .place >* .title {
@@ -13,7 +13,7 @@
 }
 
 .places .links {
-  padding: 1em 0;
+  padding: 0.75rem 0;
 }
 
 .place .button {

--- a/_sass/queercode/components/twitter.scss
+++ b/_sass/queercode/components/twitter.scss
@@ -1,3 +1,8 @@
+.twitter-timeline-container > .title {
+  margin-left: 0.75rem;
+  margin-top: 1.25rem;
+}
+
 .twitter-timeline-container {
   display: none;
 }
@@ -5,9 +10,5 @@
 @media (min-width: 770px) {
   .twitter-timeline-container {
     display: block;
-  }
-
-  .twitter > .title {
-    margin-top: 20px;
   }
 }

--- a/_sass/queercode/components/twitter.scss
+++ b/_sass/queercode/components/twitter.scss
@@ -3,10 +3,6 @@
 }
 
 @media (min-width: 770px) {
-  .twitter-link {
-    display: none;
-  }
-
   .twitter-timeline-container {
     display: block;
   }

--- a/_sass/queercode/components/twitter.scss
+++ b/_sass/queercode/components/twitter.scss
@@ -5,6 +5,9 @@
 @media (min-width: 770px) {
   .twitter-timeline-container {
     display: block;
-    margin-top: 10px;
+  }
+
+  .twitter > .title {
+    margin-top: 20px;
   }
 }

--- a/_sass/queercode/components/twitter.scss
+++ b/_sass/queercode/components/twitter.scss
@@ -5,5 +5,6 @@
 @media (min-width: 770px) {
   .twitter-timeline-container {
     display: block;
+    margin-top: 10px;
   }
 }

--- a/_sass/queercode/layout/hero.scss
+++ b/_sass/queercode/layout/hero.scss
@@ -1,5 +1,9 @@
 .hero {
+  margin-left: 10px;
+  margin-right: 10px;
   padding: 1em 1em 2em;
+  background-color: #FFE9F6;
+  border-radius: 5px;
 }
 
 .hero .title {
@@ -14,13 +18,4 @@
   font-size: 1.5em;
 }
 
-.home-image {
-  width: 100%;
-}
 
-@media (min-width: 770px) {
-  .home-image {
-    border-radius: 10px;
-    transform: translateY(2em) translateX(3em) rotate(-5deg);
-  }
-}

--- a/_sass/queercode/layout/hero.scss
+++ b/_sass/queercode/layout/hero.scss
@@ -1,8 +1,5 @@
 .hero {
-  margin-left: 10px;
-  margin-right: 10px;
-  padding: 1em 1em 2em;
-  background-color: #FFE9F6;
+  padding: 1rem 1rem 2rem 0.75rem;
   border-radius: 5px;
 }
 
@@ -19,3 +16,13 @@
 }
 
 
+.home-image {
+  width: 100%;
+}
+
+@media (min-width: 770px) {
+  .home-image {
+    border-radius: 8px;
+    transform: translateY(2em) translateX(3em) rotate(-5deg);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -25,77 +25,36 @@ layout: default
 
 <div class="columns">
   <div class="column">
+    {% for meetup in site.data.meetups %}
     <div class="place">
       <div class="columns">
         <div class="column is-one-third">
-          <img class="image" src="images/city_berlin.jpg" alt="Berlin" />
+          <img class="image" src="images/{{ meetup.image }}" alt="Berlin" />
         </div>
         <div class="column">
-          <h3 class="title">Berlin</h3>
-
+          <h3 class="title">{{ meetup.name }}</h3>
           <div class="links">
-            <a class="button is-bordered is-rainbow" href="https://www.meetup.com/Queer-Code-Berlin/">
-              <i class="fa fa-meetup" aria-hidden="true"></i> Join us
+            <a class="button is-bordered is-rainbow" href="{{ meetup.joinLink }}">
+              <i class="fa fa-{{ meetup.joinType}}" aria-hidden="true"></i> Join us
             </a>
-            <a class="navbar-item is-bordered" href="https://github.com/QueerCodeBerlin">
+            {% if meetup.github %}
+            <a class="navbar-item is-bordered" href="{{ meetup.github }}">
               <i class="fa fa-github" aria-hidden="true"></i> GitHub
             </a>
-            <a class="navbar-item twitter-link" href="https://twitter.com/QueerCodeBerlin/">
+            {% endif %}
+            <a class="navbar-item twitter-link" href="{{ meetup.twitter }}">
               <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
             </a>
-            <a class="navbar-item" href="mailto:queer-code-berlin@googlegroups.com">
+            {% if meetup.mail %}
+            <a class="navbar-item" href="{{ meetup.mail }}">
               <i class="fa fa-envelope" aria-hidden="true"></i> Google Groups
             </a>
+            {% endif %}
           </div>
         </div>
       </div>
     </div>
-    <div class="place">
-      <div class="columns">
-        <div class="column is-one-third">
-          <img class="image" src="images/city_london.jpg" alt="London" />
-        </div>
-        <div class="column">
-          <h3 class="title">London</h3>
-
-          <div class="links">
-            <a class="button is-bordered is-rainbow" href="https://www.meetup.com/Queer-Code-London/">
-              <i class="fa fa-meetup" aria-hidden="true"></i> Join us
-            </a>
-            <a class="navbar-item" href="/event-info">
-              <i class="fa fa-users" aria-hidden="true"></i> Event information
-            </a>
-            <a class="navbar-item" href="https://github.com/QCLdn">
-              <i class="fa fa-github" aria-hidden="true"></i> GitHub
-            </a>
-            <a class="navbar-item" href="mailto:qclnd-orga@googlegroups.com">
-              <i class="fa fa-envelope" aria-hidden="true"></i> Google Groups
-            </a>
-            <a class="navbar-item twitter-link" href="https://twitter.com/QCLdn/">
-              <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="place">
-      <div class="columns">
-        <div class="column is-one-third">
-          <img class="image" src="images/city_yorkshire.jpg" alt="Yorkshire" />
-        </div>
-        <div class="column">
-          <h3 class="title">Yorkshire</h3>
-          <div class="links">
-            <a class="button is-bordered is-rainbow" href="https://www.eventbrite.com/o/queer-code-yorkshire-15310069508">
-              Join us
-            </a>
-            <a class="navbar-item twitter-link" href="https://twitter.com/QueerCodeYorks">
-              <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
+    {% endfor %}
   </div>
 
   <div class="column">

--- a/index.html
+++ b/index.html
@@ -25,36 +25,39 @@ layout: default
 
 <div class="columns">
   <div class="column">
-    {% for meetup in site.data.meetups %}
-    <div class="place">
-      <div class="columns">
-        <div class="column is-one-third">
-          <img class="image" src="images/{{ meetup.image }}" alt="Berlin" />
-        </div>
-        <div class="column">
-          <h3 class="title">{{ meetup.name }}</h3>
-          <div class="links">
-            <a class="button is-bordered is-rainbow" href="{{ meetup.joinLink }}">
-              <i class="fa fa-{{ meetup.joinType}}" aria-hidden="true"></i> Join us
-            </a>
-            {% if meetup.github %}
-            <a class="navbar-item is-bordered" href="{{ meetup.github }}">
-              <i class="fa fa-github" aria-hidden="true"></i> GitHub
-            </a>
-            {% endif %}
-            <a class="navbar-item twitter-link" href="{{ meetup.twitter }}">
-              <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
-            </a>
-            {% if meetup.mail %}
-            <a class="navbar-item" href="{{ meetup.mail }}">
-              <i class="fa fa-envelope" aria-hidden="true"></i> Google Groups
-            </a>
-            {% endif %}
+    <div class="places">
+      <h2 class="title">Find your local meetup</h2>
+      {% for meetup in site.data.meetups %}
+      <div class="place">
+        <div class="columns">
+          <div class="column is-one-third">
+            <img class="image" src="images/{{ meetup.image }}" alt="Berlin" />
+          </div>
+          <div class="column">
+            <h3 class="title">{{ meetup.name }}</h3>
+            <div class="links">
+              <a class="button is-bordered is-rainbow" href="{{ meetup.joinLink }}">
+                <i class="fa fa-{{ meetup.joinType}}" aria-hidden="true"></i> Join us
+              </a>
+              {% if meetup.github %}
+              <a class="navbar-item is-bordered" href="{{ meetup.github }}">
+                <i class="fa fa-github" aria-hidden="true"></i> GitHub
+              </a>
+              {% endif %}
+              <a class="navbar-item twitter-link" href="{{ meetup.twitter }}">
+                <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
+              </a>
+              {% if meetup.mail %}
+              <a class="navbar-item" href="{{ meetup.mail }}">
+                <i class="fa fa-envelope" aria-hidden="true"></i> Google Groups
+              </a>
+              {% endif %}
+            </div>
           </div>
         </div>
       </div>
+      {% endfor %}
     </div>
-    {% endfor %}
   </div>
 
   <div class="column">

--- a/index.html
+++ b/index.html
@@ -77,21 +77,21 @@ layout: default
           </div>
         </div>
       </div>
-      <div class="place">
-        <div class="columns">
-          <div class="column is-one-third">
-            <img class="image" src="images/city_yorkshire.jpg" alt="Yorkshire" />
-          </div>
-          <div class="column">
-            <h3 class="title">Yorkshire</h3>
-            <div class="links">
-              <a class="button is-bordered is-rainbow" href="https://www.eventbrite.com/o/queer-code-yorkshire-15310069508">
-                Join us
-              </a>
-              <a class="navbar-item twitter-link" href="https://twitter.com/QueerCodeYorks">
-                <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
-              </a>
-            </div>
+    </div>
+    <div class="place">
+      <div class="columns">
+        <div class="column is-one-third">
+          <img class="image" src="images/city_yorkshire.jpg" alt="Yorkshire" />
+        </div>
+        <div class="column">
+          <h3 class="title">Yorkshire</h3>
+          <div class="links">
+            <a class="button is-bordered is-rainbow" href="https://www.eventbrite.com/o/queer-code-yorkshire-15310069508">
+              Join us
+            </a>
+            <a class="navbar-item twitter-link" href="https://twitter.com/QueerCodeYorks">
+              <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
+            </a>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -24,45 +24,44 @@ layout: default
  </div>
 
 <div class="columns">
-  <div class="column">
-    <div class="places">
-      <h2 class="title">Find your local meetup</h2>
-      {% for meetup in site.data.meetups %}
-      <div class="place">
-        <div class="columns">
-          <div class="column is-one-third">
-            <img class="image" src="images/{{ meetup.image }}" alt="Berlin" />
-          </div>
-          <div class="column">
-            <h3 class="title">{{ meetup.name }}</h3>
-            <div class="links">
-              <a class="button is-bordered is-rainbow" href="{{ meetup.joinLink }}">
-                <i class="fa fa-{{ meetup.joinType}}" aria-hidden="true"></i> Join us
-              </a>
-              {% if meetup.github %}
-              <a class="navbar-item is-bordered" href="{{ meetup.github }}">
-                <i class="fa fa-github" aria-hidden="true"></i> GitHub
-              </a>
-              {% endif %}
-              <a class="navbar-item twitter-link" href="{{ meetup.twitter }}">
-                <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
-              </a>
-              {% if meetup.mail %}
-              <a class="navbar-item" href="{{ meetup.mail }}">
-                <i class="fa fa-envelope" aria-hidden="true"></i> Google Groups
-              </a>
-              {% endif %}
-            </div>
+  <div class="column places">
+    <h2 class="title">Find your local meetup</h2>
+    {% for meetup in site.data.meetups %}
+    <div class="place">
+      <div class="columns">
+        <div class="column is-one-third">
+          <img class="image" src="images/{{ meetup.image }}" alt="Berlin" />
+        </div>
+        <div class="column">
+          <h3 class="title">{{ meetup.name }}</h3>
+          <div class="links">
+            <a class="button is-bordered is-rainbow" href="{{ meetup.joinLink }}">
+              <i class="fa fa-{{ meetup.joinType}}" aria-hidden="true"></i> Join us
+            </a>
+            {% if meetup.github %}
+            <a class="navbar-item is-bordered" href="{{ meetup.github }}">
+              <i class="fa fa-github" aria-hidden="true"></i> GitHub
+            </a>
+            {% endif %}
+            <a class="navbar-item twitter-link" href="{{ meetup.twitter }}">
+              <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
+            </a>
+            {% if meetup.mail %}
+            <a class="navbar-item" href="{{ meetup.mail }}">
+              <i class="fa fa-envelope" aria-hidden="true"></i> Google Groups
+            </a>
+            {% endif %}
           </div>
         </div>
       </div>
-      {% endfor %}
     </div>
+    {% endfor %}
   </div>
 
-  <div class="column">
+  <div class="column twitter">
+    <h2 class="title">Tweets from Queer Code groups</h2>
     <div class="twitter-timeline-container">
-      <a class="twitter-timeline" data-height="1000" data-dnt="true" href="https://twitter.com/QCLdn/lists/tweets-from-queer-code">Queer Code on Twitter</a>
+      <a class="twitter-timeline" data-height="1000" data-chrome="noheader" data-dnt="true" href="https://twitter.com/QCLdn/lists/tweets-from-queer-code">Queer Code on Twitter</a>
     </div>
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@ layout: default
     <div class="place">
       <div class="columns">
         <div class="column is-one-third">
-          <img class="image" src="images/city_london.jpg" alt="Berlin" />
+          <img class="image" src="images/city_london.jpg" alt="London" />
         </div>
         <div class="column">
           <h3 class="title">London</h3>
@@ -80,7 +80,7 @@ layout: default
       <div class="place">
         <div class="columns">
           <div class="column is-one-third">
-            <img class="image" src="images/city_yorkshire.jpg" alt="Berlin" />
+            <img class="image" src="images/city_yorkshire.jpg" alt="Yorkshire" />
           </div>
           <div class="column">
             <h3 class="title">Yorkshire</h3>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@ layout: default
 ---
  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
- <div class="hero">
 <div class="columns">
   <div class="column">
     <div class="hero">
@@ -23,7 +22,6 @@ layout: default
     <img class="home-image is-rainbow" src="images/people.jpg" alt="People at Queer Code" />
   </div>
 </div>
- </div>
 
 <div class="columns">
   <div class="column places">
@@ -60,12 +58,12 @@ layout: default
     {% endfor %}
   </div>
 
-  <div class="column twitter">
-    <h2 class="title">Tweets from Queer Code groups</h2>
+  <div class="column">
     <div class="twitter-timeline-container">
+      <h2 class="title">Tweets from Queer Code groups</h2>
       <a class="twitter-timeline" data-height="1000" data-chrome="noheader" data-dnt="true" href="https://twitter.com/QCLdn/lists/tweets-from-queer-code">Queer Code on Twitter</a>
     </div>
-  </div>
+    </div>
 </div>
 
 <div class="slack">

--- a/index.html
+++ b/index.html
@@ -3,100 +3,104 @@ title: Queer Code
 layout: default
 ---
  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+ <div class="hero">
 <div class="columns">
   <div class="column">
-    <div class="hero">
-      <h1 class="title is-spaced">
-        Queer Code
-      </h1>
-      <p class="subtitle">
-         {{ site.description }}
-      </p>
-      <p>
-        <a class="button is-bordered is-rainbow" href="/mission">Our mission</a>
-      </p>
-    </div>
+    <h1 class="title is-spaced">
+      Queer Code
+    </h1>
+    <p class="subtitle">
+    {{ site.description }}
+    </p>
+    <p>
+    <a class="button is-bordered is-rainbow" href="/mission">Our mission</a>
+    </p>
   </div>
   <div class="column">
     <img class="home-image is-rainbow" src="images/people.jpg" alt="People at Queer Code" />
   </div>
 </div>
+ </div>
 
-<div class="places">
-  <h2 class="title">Places</h2>
-
-  <div class="columns">
-    <div class="column">
-      <div class="place">
-        <h3 class="title">Berlin</h3>
-
-        <img class="image" src="images/city_berlin.jpg" alt="Berlin" />
-        
-        <div class="links">
-          <a class="button is-bordered is-rainbow" href="https://www.meetup.com/Queer-Code-Berlin/">
-            <i class="fa fa-meetup" aria-hidden="true"></i> Join us
-          </a>
-          <a class="navbar-item is-bordered" href="https://github.com/QueerCodeBerlin">
-            <i class="fa fa-github" aria-hidden="true"></i> GitHub
-          </a>
-          <a class="navbar-item twitter-link" href="https://twitter.com/QueerCodeBerlin/">
-            <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
-          </a>
-          <a class="navbar-item" href="mailto:queer-code-berlin@googlegroups.com">
-            <i class="fa fa-envelope" aria-hidden="true"></i> Google Groups
-          </a>
+<div class="columns">
+  <div class="column">
+    <div class="place">
+      <div class="columns">
+        <div class="column is-one-third">
+          <img class="image" src="images/city_berlin.jpg" alt="Berlin" />
         </div>
-        <div class="twitter-timeline-container">
-          <a class="twitter-timeline" data-height="500" href="https://twitter.com/QueerCodeBerlin?ref_src=twsrc%5Etfw">Tweets by Queer Code Berlin</a>
+        <div class="column">
+          <h3 class="title">Berlin</h3>
+
+          <div class="links">
+            <a class="button is-bordered is-rainbow" href="https://www.meetup.com/Queer-Code-Berlin/">
+              <i class="fa fa-meetup" aria-hidden="true"></i> Join us
+            </a>
+            <a class="navbar-item is-bordered" href="https://github.com/QueerCodeBerlin">
+              <i class="fa fa-github" aria-hidden="true"></i> GitHub
+            </a>
+            <a class="navbar-item twitter-link" href="https://twitter.com/QueerCodeBerlin/">
+              <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
+            </a>
+            <a class="navbar-item" href="mailto:queer-code-berlin@googlegroups.com">
+              <i class="fa fa-envelope" aria-hidden="true"></i> Google Groups
+            </a>
+          </div>
         </div>
       </div>
     </div>
-    <div class="column">
-      <div class="place">
-        <h3 class="title">London</h3>
-
-        <img class="image" src="images/city_london.jpg" alt="London" />
-            
-        <div class="links">
-          <a class="button is-bordered is-rainbow" href="https://www.meetup.com/Queer-Code-London/">
-            <i class="fa fa-meetup" aria-hidden="true"></i> Join us
-          </a>
-          <a class="navbar-item" href="/event-info">
-            <i class="fa fa-users" aria-hidden="true"></i> Event information
-          </a>
-          <a class="navbar-item" href="https://github.com/QCLdn">
-            <i class="fa fa-github" aria-hidden="true"></i> GitHub
-          </a>
-          <a class="navbar-item" href="mailto:qclnd-orga@googlegroups.com">
-            <i class="fa fa-envelope" aria-hidden="true"></i> Google Groups
-          </a>
-          <a class="navbar-item twitter-link" href="https://twitter.com/QCLdn/">
-            <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
-          </a>
+    <div class="place">
+      <div class="columns">
+        <div class="column is-one-third">
+          <img class="image" src="images/city_london.jpg" alt="Berlin" />
         </div>
-        <div class="twitter-timeline-container">
-          <a class="twitter-timeline" data-height="500" href="https://twitter.com/QCLdn?ref_src=twsrc%5Etfw">Tweets by Queer Code London</a>
+        <div class="column">
+          <h3 class="title">London</h3>
+
+          <div class="links">
+            <a class="button is-bordered is-rainbow" href="https://www.meetup.com/Queer-Code-London/">
+              <i class="fa fa-meetup" aria-hidden="true"></i> Join us
+            </a>
+            <a class="navbar-item" href="/event-info">
+              <i class="fa fa-users" aria-hidden="true"></i> Event information
+            </a>
+            <a class="navbar-item" href="https://github.com/QCLdn">
+              <i class="fa fa-github" aria-hidden="true"></i> GitHub
+            </a>
+            <a class="navbar-item" href="mailto:qclnd-orga@googlegroups.com">
+              <i class="fa fa-envelope" aria-hidden="true"></i> Google Groups
+            </a>
+            <a class="navbar-item twitter-link" href="https://twitter.com/QCLdn/">
+              <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
+            </a>
+          </div>
+        </div>
+      </div>
+      <div class="place">
+        <div class="columns">
+          <div class="column is-one-third">
+            <img class="image" src="images/city_yorkshire.jpg" alt="Berlin" />
+          </div>
+          <div class="column">
+            <h3 class="title">Yorkshire</h3>
+            <div class="links">
+              <a class="button is-bordered is-rainbow" href="https://www.eventbrite.com/o/queer-code-yorkshire-15310069508">
+                Join us
+              </a>
+              <a class="navbar-item twitter-link" href="https://twitter.com/QueerCodeYorks">
+                <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
+              </a>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-    <div class="column">
-      <div class="place">
-        <h3 class="title">Yorkshire</h3>
+  </div>
 
-        <img class="image" src="images/city_yorkshire.jpg" alt="Yorkshire" />
-        
-        <div class="links">
-          <a class="button is-bordered is-rainbow" href="https://www.eventbrite.com/o/queer-code-yorkshire-15310069508">
-            Join us
-          </a>
-          <a class="navbar-item twitter-link" href="https://twitter.com/QueerCodeYorks">
-            <i class="fa fa-twitter" aria-hidden="true"></i> Twitter
-          </a>
-        </div>
-        <div class="twitter-timeline-container">
-          <a class="twitter-timeline" data-height="500" href="https://twitter.com/QueerCodeYorks?ref_src=twsrc%5Etfw">Tweets by Queer Code Yorkshire</a>
-        </div>
-      </div>
+  <div class="column">
+    <div class="twitter-timeline-container">
+      <a class="twitter-timeline" data-height="1000" data-dnt="true" href="https://twitter.com/QCLdn/lists/tweets-from-queer-code">Queer Code on Twitter</a>
     </div>
   </div>
 </div>
@@ -105,16 +109,15 @@ layout: default
   <div class="columns">
     <div class="column">
       <h2 class="title is-spaced">We're on Slack</h2>
-      <p class="subtitle">Slack is a place where we organise events and chat to each other.</p>
+      <p class="subtitle">Chat to queer coders around the world in our Slack group.</p>
       <p>
         <a class="button is-bordered is-rainbow" href="https://slackinvite-qcldn.herokuapp.com/">
           Join us on Slack
         </a>
       </p>
     </div>
-    <div class="column is-one-fifth">
+    <div class="column is-one-third">
       <img class="logo" src="images/logo-slack.svg" alt="Slack logo" />
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
Twitter / group layout
- Pull in local group data from a data file, `_data/meetups.json`, rather than having them hardcoded in the `index.html` file.
- Uses a new two-column layout for Queer Code groups on the left, and Twitter timeline on the right
- The Twitter timeline is now based on a single list of all Queer Code groups combined. This is maintained on the @qcldn account: https://twitter.com/QCLdn/lists/tweets-from-queer-code
- Twitter links now show in both desktop and mobile views

Hero banner
- Image is adjusted so that it appears straight
- Added a pink background highlight to pull it apart from the places and twitter feeds
- Removed the 'Places' title

This fixes #49.