### PR TITLE
Add events page

### DIFF
--- a/_data/events.json
+++ b/_data/events.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Queer Code Pride Edition",
+    "location": "Makers Academy 50-52 Commercial St, E1 6LT · London",
+    "description": "This month we have two wonderful speakers to help us celebrate Pride! We'll be providing food before the talks, and there will be time to hang out and relax afterwards with your fellow queer coders.",
+    "datetime": "2019-08-04T18:00:00Z",
+    "url": "https://www.meetup.com/Queer-Code-London/events/262452231/",
+    "hostGroup": "London"
+  },
+  {
+    "name": "Breakfast & Catch-up",
+    "datetime": "2019-07-25T08:00:00Z",
+    "location": "The Warehouse, 211 Old Street, 2nd Floor, London EC1V 9NR",
+    "description": "Socialise and chat over a free-of-charge buffet breakfast. You can arrive and leave any time between 8am and 9:30am, and a hot and cold buffet breakfast will be available throughout the entire time of the event. We will be seated at the far end of the room (look to your left after signing in at reception), near the space where the food is laid out.",
+    "hostGroup": "London",
+    "url": "https://www.meetup.com/Queer-Code-London/events/262381953/"
+  }
+]

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -49,6 +49,9 @@
           <a class="navbar-item" href="/">
             Home
           </a>
+          <a class="navbar-item" href="/events">
+           Events
+          </a>
           <a class="navbar-item" href="mission">
             Mission
           </a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -46,16 +46,24 @@
 
       <div class="navbar-menu is-active" id="navMenu">
         <div class="navbar-end">
-          <a class="navbar-item" href="/">
+          <a class="navbar-item
+              {% if page.url == "/" %}is-active{% endif %}
+            " href="/">
             Home
           </a>
-          <a class="navbar-item" href="/events">
+          <a class="navbar-item
+              {% if page.url == "/events.html" %}is-active{% endif %}
+            " href="/events">
            Events
           </a>
-          <a class="navbar-item" href="mission">
+          <a class="navbar-item
+              {% if page.url == "/mission.html" %}is-active{% endif %}
+            " href="mission">
             Mission
           </a>
-          <a class="navbar-item" href="coc">
+          <a class="navbar-item
+              {% if page.url == "/coc.html" %}is-active{% endif %}
+            " href="coc">
             Code of Conduct
           </a>
           <span class="navbar-item navbar-item--slack">

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -37,7 +37,7 @@ Bulma code with equivilant custom code.
 
 // elements
 
-// @import "bulma/elements/box";
+@import "bulma/elements/box";
 @import "bulma/elements/button";
 @import "queercode/elements/button";
 @import "bulma/elements/container";

--- a/events.html
+++ b/events.html
@@ -1,0 +1,36 @@
+---
+title: Events
+layout: default
+---
+
+<div class="columns is-centered">
+<div class="column is-half">
+<h1 class="title is-1">Events</h1>
+{% for event in site.data.events %}
+  <div class="box content">
+    <p>
+    <strong class="is-size-4">{{ event.name }}</strong><small>,
+      {%- if event.datetime %}
+        {{ event.datetime | date_to_long_string }}
+        {{ event.datetime | date: "%I:%M%P" }}
+      {%- else %}
+       date <abbr title="To be confirmed">TBC</abbr>
+      {%- endif %}, {{event.hostGroup}}
+    </small>
+      <br>
+      {% if event.description %}
+          {{ event.description }}
+          {% if event.url %}
+          <div class="is-pulled-right"><a href="{{event.url}}">Find out more</a></div>
+          {% endif %}
+      {% else %}
+        {% if event.url %}
+          <a href="{{event.url}}">Find out more</a>
+        {% endif %}
+      {% endif %}
+    </p>
+  </div>
+{% endfor %}
+<p></p>
+</div>
+</div>


### PR DESCRIPTION
First pass on an events page, we might want to collect data for more of the past events before landing this.

@dirv, maybe instead of putting the events data in json file under `_data` each event could be a post under `_posts`? That way it might be easier to resolve #56 later.

<img width="1440" alt="Screenshot 2019-08-11 at 16 08 49" src="https://user-images.githubusercontent.com/351085/62835630-97b3e480-bc52-11e9-9d8f-9fe5ef373033.png"> 